### PR TITLE
fix: divizion by zero 

### DIFF
--- a/v3/generate_abi_dbs.py
+++ b/v3/generate_abi_dbs.py
@@ -146,7 +146,7 @@ def merge_abis_to_sqlite(chain_name, db_target_path, contracts_path):
     fileslist = os.listdir(contracts_path)
 
     if len(fileslist):
-        sum_of_file = len(fileslist) - 1
+        sum_of_file = len(fileslist)
         location = 0
         for file in fileslist:
             if file.endswith(".json"):


### PR DESCRIPTION
If the chain directory contains exactly one `.json` file, the db generation script fails with division by zero error.

It seems there is no reason to subtract 1 from the length of the files list.
